### PR TITLE
Support accessing methods from anonymous classes via proxies

### DIFF
--- a/develocity-gradle-plugin-adapters/src/compatibilityApi/java/com/gradle/develocity/agent/gradle/adapters/internal/ProxyFactory.java
+++ b/develocity-gradle-plugin-adapters/src/compatibilityApi/java/com/gradle/develocity/agent/gradle/adapters/internal/ProxyFactory.java
@@ -35,6 +35,10 @@ public final class ProxyFactory {
             try {
                 Method targetMethod = target.getClass().getMethod(method.getName(), convertTypes(method.getParameterTypes(), target.getClass().getClassLoader()));
                 Object[] targetArgs = toTargetArgs(args);
+
+                // we always invoke public methods, but we need to make it accessible when it is implemented in anonymous classes
+                targetMethod.setAccessible(true);
+
                 Object result = targetMethod.invoke(target, targetArgs);
                 if (result == null || isJdkType(result.getClass())) {
                     return result;

--- a/develocity-gradle-plugin-adapters/src/develocityCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/develocity/BuildScanConfigurationAdapterTest.java
+++ b/develocity-gradle-plugin-adapters/src/develocityCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/develocity/BuildScanConfigurationAdapterTest.java
@@ -21,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
+import java.util.List;
 
 import static com.gradle.develocity.agent.gradle.adapters.ActionMockFixtures.doExecuteActionWith;
 import static com.gradle.develocity.agent.gradle.adapters.PropertyMockFixtures.mockProperty;
@@ -163,11 +164,16 @@ public class BuildScanConfigurationAdapterTest {
 
     @Test
     @DisplayName("build finished action can be configured via an adapter using the new build result model")
+    @SuppressWarnings("Convert2Lambda")
     void testBuildFinishedAction() {
         // given
         Throwable failure = new RuntimeException("New build failure!");
-        BuildResult buildResult = mock();
-        when(buildResult.getFailures()).thenReturn(Collections.singletonList(failure));
+        BuildResult buildResult = new BuildResult() {
+            @Override
+            public List<Throwable> getFailures() {
+                return Collections.singletonList(failure);
+            }
+        };
 
         // and
         doExecuteActionWith(buildResult).when(configuration).buildFinished(any());

--- a/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanExtensionAdapterTest.java
+++ b/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanExtensionAdapterTest.java
@@ -1,6 +1,5 @@
 package com.gradle.develocity.agent.gradle.adapters.enterprise;
 
-import com.gradle.develocity.agent.gradle.adapters.ActionMockFixtures;
 import com.gradle.develocity.agent.gradle.adapters.ActionMockFixtures.ArgCapturingAction;
 import com.gradle.develocity.agent.gradle.adapters.BuildResultAdapter;
 import com.gradle.develocity.agent.gradle.adapters.BuildScanAdapter;
@@ -17,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.net.URI;
 import java.util.Collections;
 
 import static com.gradle.develocity.agent.gradle.adapters.ActionMockFixtures.doExecuteActionWith;
@@ -158,11 +158,16 @@ class BuildScanExtensionAdapterTest {
 
     @Test
     @DisplayName("can run the build finished action using the proxy")
+    @SuppressWarnings("Convert2Lambda")
     void testBuildFinishedAction() {
         // given
         Throwable failure = new RuntimeException("Boom!");
-        BuildResult buildResult = mock();
-        when(buildResult.getFailure()).thenReturn(failure);
+        BuildResult buildResult = new BuildResult() {
+            @Override
+            public Throwable getFailure() {
+                return failure;
+            }
+        };
         doExecuteActionWith(buildResult).when(extension).buildFinished(any());
 
         // when
@@ -177,8 +182,17 @@ class BuildScanExtensionAdapterTest {
     @DisplayName("can run the build scan published action using the proxy")
     void testBuildScanPublishedAction() {
         // given
-        PublishedBuildScan scan = mock();
-        when(scan.getBuildScanId()).thenReturn("scanId");
+        PublishedBuildScan scan = new PublishedBuildScan() {
+            @Override
+            public String getBuildScanId() {
+                return "scanId";
+            }
+
+            @Override
+            public URI getBuildScanUri() {
+                return null;
+            }
+        };
         doExecuteActionWith(scan).when(extension).buildScanPublished(any());
 
         // when

--- a/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanExtension_1_X_AdapterTest.java
+++ b/develocity-gradle-plugin-adapters/src/enterpriseCompatibilityTest/java/com/gradle/develocity/agent/gradle/adapters/enterprise/BuildScanExtension_1_X_AdapterTest.java
@@ -1,18 +1,20 @@
 package com.gradle.develocity.agent.gradle.adapters.enterprise;
 
-import com.gradle.develocity.agent.gradle.adapters.ActionMockFixtures;
 import com.gradle.develocity.agent.gradle.adapters.ActionMockFixtures.ArgCapturingAction;
 import com.gradle.develocity.agent.gradle.adapters.BuildResultAdapter;
 import com.gradle.develocity.agent.gradle.adapters.DevelocityAdapter;
 import com.gradle.develocity.agent.gradle.adapters.PublishedBuildScanAdapter;
 import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
+import com.gradle.scan.plugin.BuildResult;
 import com.gradle.scan.plugin.BuildScanExtension;
+import com.gradle.scan.plugin.PublishedBuildScan;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.net.URI;
 import java.util.Collections;
 
 import static com.gradle.develocity.agent.gradle.adapters.ActionMockFixtures.doExecuteActionWith;
@@ -25,7 +27,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class BuildScanExtension_1_X_AdapterTest {
@@ -221,11 +222,16 @@ public class BuildScanExtension_1_X_AdapterTest {
 
     @Test
     @DisplayName("build finished action can be configured via an adapter using the new build result model")
+    @SuppressWarnings("Convert2Lambda")
     void testBuildFinishedAction() {
         // given
         Throwable failure = new RuntimeException("Old build failure!");
-        com.gradle.scan.plugin.BuildResult buildResult = mock();
-        when(buildResult.getFailure()).thenReturn(failure);
+        BuildResult buildResult = new BuildResult() {
+            @Override
+            public Throwable getFailure() {
+                return failure;
+            }
+        };
 
         // and
         doExecuteActionWith(buildResult).when(extension).buildFinished(any());
@@ -242,8 +248,17 @@ public class BuildScanExtension_1_X_AdapterTest {
     @DisplayName("build scan published action can be configured via an adapter using the new scan model")
     void testBuildScanPublishedAction() {
         // given
-        com.gradle.scan.plugin.PublishedBuildScan publishedScan = mock();
-        when(publishedScan.getBuildScanId()).thenReturn("scanId");
+        PublishedBuildScan publishedScan = new PublishedBuildScan() {
+            @Override
+            public String getBuildScanId() {
+                return "scanId";
+            }
+
+            @Override
+            public URI getBuildScanUri() {
+                return null;
+            }
+        };
         doExecuteActionWith(publishedScan).when(extension).buildScanPublished(any());
 
         // when


### PR DESCRIPTION
## Summary

Our configuration and extension proxies will always invoke public classes. However, objects that we proxy to might be defined using anonymous classes. In that case, we need to make the method accessible, as the anonymous class won't have the "public" visibility.