### PR TITLE
Allow internal publishing with insecure checksum

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 group=com.gradle
 org.gradle.java.installations.fromEnv=JDK8
+systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
This seems to be necessary to address the problem [here](https://github.com/gradle/develocity-artifactory/issues/84)