### PR TITLE
Adapt supplied enum values to the proxy's target enum types

### DIFF
--- a/buildSrc/src/main/kotlin/develocity/adapters/develocity.adapters-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/develocity/adapters/develocity.adapters-library.gradle.kts
@@ -51,6 +51,17 @@ dependencies {
 
 testing {
     suites {
+        val compatibilityApiTest by creating(JvmTestSuite::class) {
+            useJUnitJupiter()
+
+            dependencies {
+                implementation(sourceSetOutput("compatibilityApi"))
+                implementation(testFixtures(project()))
+                implementation(platform(libs.junit.bom))
+                implementation("org.junit.jupiter:junit-jupiter")
+            }
+        }
+
         val enterpriseCompatibilityTest by creating(JvmTestSuite::class) {
             useJUnitJupiter()
 

--- a/develocity-gradle-plugin-adapters/src/compatibilityApiTest/java/com/gradle/develocity/agent/adapters/gradle/internal/ProxyFactoryTest.java
+++ b/develocity-gradle-plugin-adapters/src/compatibilityApiTest/java/com/gradle/develocity/agent/adapters/gradle/internal/ProxyFactoryTest.java
@@ -1,0 +1,62 @@
+package com.gradle.develocity.agent.adapters.gradle.internal;
+
+import com.gradle.develocity.agent.gradle.adapters.internal.ProxyFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ProxyFactoryTest {
+
+    @Test
+    @DisplayName("adapts enum method arguments")
+    void testEnumArg() {
+        // given
+        TargetWithEnum target = new TargetWithEnumImpl();
+        TargetWithEnum proxy = ProxyFactory.createProxy(target, TargetWithEnum.class);
+
+        // when
+        String result = proxy.methodWithEnumArg(TargetWithEnum.TargetEnum.B);
+
+        // then
+        assertEquals("B", result);
+    }
+
+    @Test
+    @DisplayName("adapts enum return values")
+    void testEnumReturn() {
+        // given
+        TargetWithEnum target = new TargetWithEnumImpl();
+        TargetWithEnum proxy = ProxyFactory.createProxy(target, TargetWithEnum.class);
+
+        // when
+        TargetWithEnum.TargetEnum result = proxy.methodReturningEnum();
+
+        // then
+        assertEquals(TargetWithEnum.TargetEnum.A, result);
+    }
+
+    interface TargetWithEnum {
+        enum TargetEnum {
+            A, B, C
+        }
+
+        String methodWithEnumArg(TargetEnum arg);
+
+        TargetEnum methodReturningEnum();
+    }
+
+    class TargetWithEnumImpl implements TargetWithEnum {
+
+        @Override
+        public String methodWithEnumArg(TargetEnum arg) {
+            return arg.name();
+        }
+
+        @Override
+        public TargetEnum methodReturningEnum() {
+            return TargetEnum.A;
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

Updating the ProxyFactory to allow setting enum properties on the proxied instances. This is relevant when interacting with the PTS configuration proxy and setting `mode` and `profile` properties. 

I added some tests that confirm that we handle enums one way or another, but they don't actually check that it works across classloader boundaries. I did some manual tests on [the reproducer](https://github.com/pshevche/reproducers/blob/main/pts-configuration-init-script/buildSrc/src/main/kotlin/predictive-test-selection-conventions.gradle.kts) that we shared with the customer to confirm that it works e2e.

Let me know if you have any suggestions how to better test it.