### PR TITLE
Prevent GE plugin and extension versions from being updated

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,6 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "github>gradle/renovate-agent//presets/dv.json5"
+  ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
     "github>gradle/renovate-agent//presets/dv.json5"
+  ],
+  "packageRules": [
+    {
+      "description": "Use the last version of the Gradle Enterprise plugin and extension that does not provide the Develocity API",
+      "matchDepNames": [
+        "com.gradle:gradle-enterprise-gradle-plugin",
+        "com.gradle:gradle-enterprise-maven-extension"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
We pin these versions to the last versions that do not provide the Develocity API, as those are the versions that adapters will likely be used with.