### PR TITLE
Pin JUnit to 5.x for Java 8 compatibility

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,13 @@
         "org.mockito:mockito-core"
       ],
       "allowedVersions": "^4.0.0"
+    },
+    {
+      "description": "JUnit 6+ requires Java 17+, but this project targets Java 8",
+      "matchDepNames": [
+        "org.junit:junit-bom"
+      ],
+      "allowedVersions": "^5.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a Renovate package rule to restrict `org.junit:junit-bom` to `^5.0.0`
- JUnit 6+ requires Java 17+, but this project targets Java 8
- Follows the same pattern already used for Mockito (`^4.0.0`)

Fixes the failing build on #162 by preventing Renovate from proposing incompatible major version bumps.

## Test plan
- [ ] Verify Renovate no longer proposes JUnit 6.x updates
- [ ] Close #162 after this is merged