### PR TITLE
Align Renovate config with team conventions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  extends: [
-    "github>gradle/renovate-agent//presets/dv-automerge-minor.json5"
+  "extends": [
+    "config:recommended",
+    "github>gradle/renovate-agent//presets/dv-automerge-minor.json5",
+    ":disableDependencyDashboard"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- Adds `config:recommended` base preset (was missing, unlike all other repo-duty repos)
- Adds `:disableDependencyDashboard` to suppress the dashboard issue (consistent with other repos)

## Test plan
- [ ] Verify no Renovate dependency dashboard issue is created after merge
- [ ] Confirm existing Renovate PRs continue to work as expected